### PR TITLE
Upgrade Credo to v1.1.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 21.3.6
+elixir 1.10.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ after_success: "./script/push"
 services:
 - docker
 elixir:
-- 1.5.0
+- 1.10.0
 cache:
   directories:
   - _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 elixir:
 - 1.10.0
 otp_release:
-- 21
+- 21.3
 cache:
   directories:
   - _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ services:
 - docker
 elixir:
 - 1.10.0
+otp_release:
+- 21
 cache:
   directories:
   - _build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.5.1-alpine
+FROM elixir:1.10-alpine
 MAINTAINER SourceLevel <support@sourcelevel.io>
 
 WORKDIR /usr/src/engine

--- a/lib/engine_credo/config.ex
+++ b/lib/engine_credo/config.ex
@@ -56,8 +56,12 @@ defmodule EngineCredo.Config do
   end
 
   defp read_config_file(path) do
+    exec = Credo.Execution.build()
+    Credo.Execution.Task.run(Credo.Execution.Task.AppendDefaultConfig, exec)
+
     # true required for safe loading of `.credo.exs`.
-    {:ok, result} = Credo.ConfigFile.read_or_default(path, nil, true)
+    {:ok, result} = Credo.ConfigFile.read_or_default(exec, path, nil, true)
+
     result
   end
 

--- a/lib/engine_credo/issue_categories.ex
+++ b/lib/engine_credo/issue_categories.ex
@@ -12,6 +12,7 @@ defmodule EngineCredo.IssueCategories do
     Credo.Check.Consistency.TabsOrSpaces => "Style",
     Credo.Check.Consistency.ParameterPatternMatching => "Style",
     Credo.Check.Consistency.MultiAliasImportRequireUse => "Style",
+    Credo.Check.Consistency.UnusedVariableNames => "Style",
 
     Credo.Check.Design.AliasUsage => "Clarity",
     Credo.Check.Design.DuplicatedCode => "Duplication",
@@ -19,10 +20,12 @@ defmodule EngineCredo.IssueCategories do
     Credo.Check.Design.TagTODO => "Bug Risk",
 
     Credo.Check.Readability.AliasOrder => "Style",
+    Credo.Check.Readability.AliasAs => "Style",
     Credo.Check.Readability.FunctionNames => "Style",
     Credo.Check.Readability.LargeNumbers => "Style",
     Credo.Check.Readability.UnnecessaryAliasExpansion => "Style",
     Credo.Check.Readability.MaxLineLength => "Style",
+    Credo.Check.Readability.MultiAlias => "Style",
     Credo.Check.Readability.ModuleAttributeNames => "Style",
     Credo.Check.Readability.ModuleDoc => "Clarity",
     Credo.Check.Readability.ModuleNames => "Style",
@@ -59,6 +62,7 @@ defmodule EngineCredo.IssueCategories do
     Credo.Check.Refactor.AppendSingleItem => "Clarity",
     Credo.Check.Refactor.LongQuoteBlocks => "Clarity",
     Credo.Check.Refactor.MapInto => "Clarity",
+    Credo.Check.Refactor.WithClauses => "Clarity",
 
     Credo.Check.Warning.UnsafeToAtom => "Bug Risk",
     Credo.Check.Warning.BoolOperationOnSameValues => "Bug Risk",

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule EngineCredo.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:credo, "~> 1.0"},
+      {:credo, "~> 1.1.5"},
       {:poison, "~> 2.2"},
       {:briefly, "~> 0.3", only: :test}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
-  "briefly": {:hex, :briefly, "0.3.0", "16e6b76d2070ebc9cbd025fa85cf5dbaf52368c4bd896fb482b5a6b95a540c2f", [:mix], [], "hexpm"},
-  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
-  "credo": {:hex, :credo, "1.0.4", "d2214d4cc88c07f54004ffd5a2a27408208841be5eca9f5a72ce9e8e835f7ede", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
-  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
-  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], [], "hexpm"},
+  "briefly": {:hex, :briefly, "0.3.0", "16e6b76d2070ebc9cbd025fa85cf5dbaf52368c4bd896fb482b5a6b95a540c2f", [:mix], [], "hexpm", "c6ebf8fc3dcd4950dd10c03e953fb4f553a8bcf0ff4c8c40d71542434cd7e046"},
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
+  "credo": {:hex, :credo, "1.1.5", "caec7a3cadd2e58609d7ee25b3931b129e739e070539ad1a0cd7efeeb47014f4", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "d0bbd3222607ccaaac5c0340f7f525c627ae4d7aee6c8c8c108922620c5b6446"},
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "fdf843bca858203ae1de16da2ee206f53416bbda5dc8c9e78f43243de4bc3afe"},
+  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], [], "hexpm", "519bc209e4433961284174c497c8524c001e285b79bdf80212b47a1f898084cc"},
 }


### PR DESCRIPTION
## Engine

- Use `Credo.Execution`
- Manually invoke append default config task for `Credo.Execution`
- Categorize new checks
- Upgrade Elixir to 1.10 and Erlang to 21.3
  - [x] Travis CI
  - [x] Dockerfile
- Introduce `.tool-versions` file

## Credo

- [1.0.5 .. 1.1.5 Diff](https://github.com/rrrene/credo/compare/v1.0.5...v1.1.5)

<details>

<summary>Changelog</summary>



---

## 1.1.5

- Add JSON output to `categories` and `explain` commands
- Include number of executed checks in summary
- Fix wrong trigger in `SinglePipe`

## 1.1.4

- Fix name parsing bug in `UnusedVariableNames`
- Fix bug when redefining operators in `FunctionNames`
- Fix false positive in `Specs`

## 1.1.3

- Improve warning message about skipped checks
- Fix false positive in `FunctionNames`
- Fix typespec in `IssueMeta`
- Add `AliasAs` check to list of optional checks

## 1.1.2

- Fix bug in `Heredocs` regarding indentation
- Fix bug in `FunctionNames` when using `unquote/1` in guards
- Fix bug in `FunctionNames` when defining `sigil_` functions for uppercase sigils

## 1.1.1

- Fix incompatibilities between Elixir 1.9, `Credo.Code.Token` and  `Credo.Code.InterpolationHelper`
- Fix error in `Heredocs` with certain UTF-8 chars
- New param for `ParenthesesOnZeroArityDefs`: use `[parens: true]` to force presence of parentheses on zero arity defs

## 1.1.0

- Credo now requires Elixir 1.5 and Erlang/OTP 19
- Fix false negative in `DuplicatedCode`
- `PipeChainStart` has been made opt-in

### Plugin Support

Credo now supports plugins that run alongside Credo's own analysis. While Credo provided the ability to write custom checks since `v0.4.0`, users can now access the complete toolset of Credo to create their own commands, require compilation, run external tools and still include the results in Credo's standard report.

Please refer to Credo's [README](https://github.com/rrrene/credo#plugins) as well as the [Credo Demo Plugin](https://github.com/rrrene/credo_demo_plugin) for further information on how to get started.

### New checks

- Credo.Check.Refactor.WithClauses

</details>