### PR TITLE
Add System stacktrace to exception details output

### DIFF
--- a/lib/engine_credo/cli.ex
+++ b/lib/engine_credo/cli.ex
@@ -17,7 +17,7 @@ defmodule EngineCredo.CLI do
   rescue
     error ->
       # credo:disable-for-next-line Credo.Check.Warning.IoInspect
-      IO.puts(:stderr, Exception.format(:error, error, System.stacktrace()))
+      IO.puts(:stderr, Exception.format(:error, error, __STACKTRACE__))
       System.halt(1)
   end
 end

--- a/lib/engine_credo/cli.ex
+++ b/lib/engine_credo/cli.ex
@@ -17,7 +17,7 @@ defmodule EngineCredo.CLI do
   rescue
     error ->
       # credo:disable-for-next-line Credo.Check.Warning.IoInspect
-      IO.puts(:stderr, Exception.format(:error, error))
+      IO.puts(:stderr, Exception.format(:error, error, System.stacktrace()))
       System.halt(1)
   end
 end


### PR DESCRIPTION
This will provide more detailed error messages for SourceLevel users, instead of receiving this:

![image](https://user-images.githubusercontent.com/645452/75741768-5cf6c400-5cea-11ea-8a96-17566760fe56.png)

They will receive this:

![image](https://user-images.githubusercontent.com/645452/75741802-74ce4800-5cea-11ea-8f34-fea86c0619cf.png)
